### PR TITLE
Do not provide test-helper feature

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -33,6 +33,4 @@
 (require 'ert)
 (require 'ede-php-autoload)
 
-(provide 'test-helper)
-
 ;;; test-helper.el ends here


### PR DESCRIPTION
"test-helper.el" isn't a library intended to be loaded with `require`.
Instead it loaded with `load`.  Because of that, it is confusing to
provide a feature using `provide` anyway.  And furthermore, because
around 70 other packages come with a file named "test-helper.el" and
several dozen of those still provide the feature `test-helper`, this
also leads to a, admittedly somewhat theoretical, feature conflict.

This is also discussed at https://github.com/rejeep/ert-runner.el/issues/38.